### PR TITLE
Fixes related to runes

### DIFF
--- a/Content/Items/Accessories/Runes/RuneItem.cs
+++ b/Content/Items/Accessories/Runes/RuneItem.cs
@@ -1,5 +1,8 @@
-﻿using AssortedAdditions.Common.Players;
+﻿using System.Collections.Generic;
+using System.Linq;
+using AssortedAdditions.Common.Players;
 using Terraria;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.Utilities;
 
@@ -10,16 +13,23 @@ namespace AssortedAdditions.Content.Items.Accessories.Runes
 	/// Disables prefixes (modifiers/forging) of these items.
 	/// Other use is to check if the item is a RuneItem type in RuneSlot.cs
 	/// </summary>
-	public abstract class RuneItem : ModItem 
+	public abstract class RuneItem : ModItem
 	{
 		public override bool CanEquipAccessory(Player player, int slot, bool modded)
 		{
-			return slot == ModContent.GetInstance<RuneSlot>().Type; // Can only be equipped in the rune slot
+			return modded & slot == ModContent.GetInstance<RuneSlot>().Type; // Can only be equipped in the rune slot
 		}
 
 		public override bool? PrefixChance(int pre, UnifiedRandom rand)
 		{
 			return false;
+		}
+
+		// If a rune item adds some unique tooltip modifications by overriding, remember to call base so this gets added as well.
+		public override void ModifyTooltips(List<TooltipLine> tooltips)
+		{
+			TooltipLine tip = tooltips.FirstOrDefault(tip => tip.Name == "Equipable");
+			tip.Text = Language.GetTextValue("Can be equipped in the " + "[c/FFF014:Rune Slot]");
 		}
 	}
 }

--- a/Content/Items/Accessories/Runes/RuneOfHealth.cs
+++ b/Content/Items/Accessories/Runes/RuneOfHealth.cs
@@ -49,6 +49,7 @@ namespace AssortedAdditions.Content.Items.Accessories.Runes
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips)
 		{
+			base.ModifyTooltips(tooltips); // Call base so RuneItem can replace the "Equipable" tip with a custom one
 			tooltips.Insert(tooltips.FindLastIndex(tip => tip.Name.StartsWith("Tooltip")) + 1,
 				new(Mod, "Tooltip3", "Press " + CustomKeyBinds.RuneAbility.GetAssignedKeys().FirstOrDefault("<Unbound>") + " to heal"));
 		}

--- a/Content/Items/Accessories/Runes/RuneOfRelocation.cs
+++ b/Content/Items/Accessories/Runes/RuneOfRelocation.cs
@@ -67,6 +67,7 @@ namespace AssortedAdditions.Content.Items.Accessories.Runes
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips)
 		{
+			base.ModifyTooltips(tooltips); // Call base so RuneItem can replace the "Equipable" tip with a custom one
 			tooltips.Insert(tooltips.FindLastIndex(tip => tip.Name.StartsWith("Tooltip")) + 1,
 				new(Mod, "Tooltip3", "Press " + CustomKeyBinds.RuneAbility.GetAssignedKeys().FirstOrDefault("<Unbound>") + " to teleport to mouse position"));
 		}

--- a/Content/Items/Accessories/Runes/RuneOfShadows.cs
+++ b/Content/Items/Accessories/Runes/RuneOfShadows.cs
@@ -39,6 +39,7 @@ namespace AssortedAdditions.Content.Items.Accessories.Runes
 
 		public override void ModifyTooltips(List<TooltipLine> tooltips)
 		{
+			base.ModifyTooltips(tooltips); // Call base so RuneItem can replace the "Equipable" tip with a custom one
 			tooltips.Insert(tooltips.FindLastIndex(tip => tip.Name.StartsWith("Tooltip")) + 1, 
 				new(Mod, "Tooltip3", "Press " + CustomKeyBinds.RuneAbility.GetAssignedKeys().FirstOrDefault("<Unbound>") + " to use an ability"));
 		}

--- a/build.txt
+++ b/build.txt
@@ -1,3 +1,3 @@
 displayName = Assorted Additions
 author = Jesse.
-version = 0.1.0.3
+version = 0.1.0.4

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
-[B]v0.1.0.3[/B]
+[B]v0.1.0.4[/B]
 
 [LIST]
-[*] Added recipes for some items added by the mod that could previously only be found inside chests.
-[*] Reduced Dune Ore spawn rate slightly.
+[*] Fixed a bug where runes could be quick swapped with regular accessories when the Rune Slot is not unlocked. (Runes could be equipped into regular slots)
+[*] Edited the tooltip for all runes to indicate that they can only be equipped in the Rune Slot.
 [/LIST]
 


### PR DESCRIPTION
- Fixed a bug where runes could be quick swapped with regular accessories when the Rune Slot is not unlocked. (Runes could be equipped into regular slots)
- Edited the tooltip for all runes to indicate that they can only be equipped in the Rune Slot.