### PR TITLE
v0.1.1.3 - Fixed rare crash, no more errors in logs

### DIFF
--- a/Common/Players/RuneSlot.cs
+++ b/Common/Players/RuneSlot.cs
@@ -39,6 +39,14 @@ namespace AssortedAdditions.Common.Players
 
 		public override bool IsEnabled()
 		{
+			// For some reason GetModPlayer causes an error during loading
+			// Everything would work 99.9% of the time, could very rarely crash
+			// This is how calamity dealt with the issue
+			if (!Player.active) 
+			{
+				return false;
+			}
+
 			return Player.GetModPlayer<PlayerUnlocks>().runeSlotUnlocked;
 		}
 

--- a/Content/Tiles/Banners/MonsterBanners.cs
+++ b/Content/Tiles/Banners/MonsterBanners.cs
@@ -32,10 +32,10 @@ namespace AssortedAdditions.Content.Tiles.Banners
             Main.tileNoAttach[Type] = true;
             Main.tileLavaDeath[Type] = true;
             TileID.Sets.DisableSmartCursor[Type] = true;
-            TileObjectData.newTile.StyleHorizontal = true;
 
             TileObjectData.newTile.CopyFrom(TileObjectData.Style1x2Top);
-            TileObjectData.newTile.Height = 3;
+			TileObjectData.newTile.StyleHorizontal = true;
+			TileObjectData.newTile.Height = 3;
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 16 };
             TileObjectData.newTile.AnchorTop = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide | AnchorType.SolidBottom, TileObjectData.newTile.Width, 0);
             TileObjectData.newTile.StyleWrapLimit = 111;

--- a/build.txt
+++ b/build.txt
@@ -1,3 +1,3 @@
 displayName = Assorted Additions
 author = Jesse.
-version = 0.1.1.2
+version = 0.1.1.3

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,15 +1,7 @@
-[B]v0.1.1.2[/B]
+[B]v0.1.1.3[/B]
 
 [LIST]
-[*] Added Boss Checklist support
-[*] Fire Dragon boss improvements: It now flies a lot faster when going straight, but turns slower. Also tweaked the attack pattern to change states faster and slightly increased max health and defense
-[*] All swords now allow the player to turn while swinging
-[*] Reduced the spawn chance of Haunted Pots by around 33%
-[*] Cosmic Tome's projectiles now work underground (tile collision logic similar to starfury)
-[*] Shooting Star (bow) projectiles are now homing
-[*] Phantasmic Blade's & Phantasmic Bow's projectiles no longer hit friendly NPCs
-[*] Added a shader trail to Draconic Bow's projectile
-[*] Improved steel weapon/tool sprites
-[*] Assigined "DamageType" to some weapons that had it missing (They should now show up on lists that rely on this info). The weapons in question did not deal damage themselves, but their projectiles did so the damage values are still going to be the same.
+[*] Fixed banner tiles not loading properly (unsure if this ever caused actual problems other than warnings in the logs)
+[*] Fixed rune slot loading (should no longer crash in very rare cases)
 [/LIST]
 


### PR DESCRIPTION
- Fixed banner tiles not loading properly (unsure if this ever caused actual problems other than warnings in the logs)
- Fixed rune slot loading (should no longer crash in very rare cases)