### PR TITLE
v0.1.1.7 - Hardmode ore progression balancing + fixes

### DIFF
--- a/Common/GlobalItems/NewRecipes.cs
+++ b/Common/GlobalItems/NewRecipes.cs
@@ -13,7 +13,7 @@ namespace AssortedAdditions.Common.GlobalItems
     {
         public override void AddRecipes()
         {
-            Recipe torch = Recipe.Create(ItemID.Torch, 10);
+			Recipe torch = Recipe.Create(ItemID.Torch, 10);
             torch.AddIngredient(ModContent.ItemType<CoalChunk>());
             torch.AddRecipeGroup("Wood");
             torch.Register();

--- a/Common/GlobalNPCs/ModifiedLootDrops.cs
+++ b/Common/GlobalNPCs/ModifiedLootDrops.cs
@@ -56,6 +56,49 @@ namespace AssortedAdditions.Common.GlobalNPCs
 					npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<RuneOfProsperity>(), 15));
 					break;
 
+				// Celestial Pillars
+				case NPCID.SolarCorite:
+				case NPCID.SolarSolenian:
+				case NPCID.SolarSroller:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentSolar, 10, 1, 2));
+					break;
+				case NPCID.SolarSpearman:
+				case NPCID.SolarDrakomire:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentSolar, 6, 2, 3));
+					break;
+				case NPCID.SolarCrawltipedeHead:
+				case NPCID.SolarDrakomireRider:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentSolar, 4, 3, 4));
+					break;
+				case NPCID.VortexHornet:
+				case NPCID.VortexLarva:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentVortex, 10, 1, 2));
+					break;
+				case NPCID.VortexHornetQueen:
+				case NPCID.VortexRifleman:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentVortex, 4, 3, 4));
+					break;
+				case NPCID.VortexSoldier:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentVortex, 6, 2, 3));
+					break;
+				case NPCID.NebulaHeadcrab:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentNebula, 10, 1, 2));
+					break;
+				case NPCID.NebulaBeast:
+				case NPCID.NebulaBrain:
+				case NPCID.NebulaSoldier:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentNebula, 6, 2, 3));
+					break;
+				case NPCID.StardustCellBig:
+				case NPCID.StardustCellSmall:
+				case NPCID.StardustJellyfishBig:
+				case NPCID.StardustSpiderBig:
+				case NPCID.StardustSpiderSmall:
+				case NPCID.StardustSoldier:
+				case NPCID.StardustWormHead:
+					npcLoot.Add(ItemDropRule.Common(ItemID.FragmentStardust, 10, 2, 3));
+					break;
+
 				#endregion
 
 				#region NORMAL ENEMIES

--- a/Common/GlobalTiles/HardmodeOreProgression.cs
+++ b/Common/GlobalTiles/HardmodeOreProgression.cs
@@ -1,4 +1,6 @@
 ﻿using AssortedAdditions.Common.Configs;
+using AssortedAdditions.Common.Systems;
+using AssortedAdditions.Helpers;
 using Terraria;
 using Terraria.ID;
 using Terraria.ModLoader;
@@ -18,46 +20,19 @@ namespace AssortedAdditions.Common.GlobalTiles
                 switch (type)
                 {
                     case TileID.Mythril:
-                        if (Condition.DownedMechBossAny.IsMet())
-                        {
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
+                        return NPC.downedMechBossAny || DownedBossSystem.downedFireDragon;
 
                     case TileID.Orichalcum:
-                        if (Condition.DownedMechBossAny.IsMet())
-                        {
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
+                        return NPC.downedMechBossAny || DownedBossSystem.downedFireDragon;
 
                     case TileID.Adamantite:
-                        if (NPC.downedMechBoss1 && NPC.downedMechBoss2)
-                        {
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
+						return HelperMethods.AtLeastTrue(2, NPC.downedMechBoss1, NPC.downedMechBoss2, NPC.downedMechBoss3);
 
-                    case TileID.Titanium:
-                        if (NPC.downedMechBoss1 && NPC.downedMechBoss2)
-                        {
-                            return true;
-                        }
-                        else
-                        {
-                            return false;
-                        }
 
-                    default:
+					case TileID.Titanium:
+						return HelperMethods.AtLeastTrue(2, NPC.downedMechBoss1, NPC.downedMechBoss2, NPC.downedMechBoss3);
+
+					default:
                         break;
                 }
             }

--- a/Common/Systems/ModifiedRecipes.cs
+++ b/Common/Systems/ModifiedRecipes.cs
@@ -1,4 +1,5 @@
-﻿using AssortedAdditions.Common.Configs;
+﻿using System.Collections.Generic;
+using AssortedAdditions.Common.Configs;
 using AssortedAdditions.Content.Items.Placeables.Ores;
 using Terraria;
 using Terraria.ID;
@@ -11,45 +12,86 @@ namespace AssortedAdditions.Common.Systems
     {
         public override void PostAddRecipes()
         {
-            // The player can disable these changes if they want to in the mod configs
-            if (ModContent.GetInstance<ServerSidedToggles>().ModifiedRecipesToggle)
-            {
-                for (int i = 0; i < Recipe.numRecipes; i++)
-                {
-                    Recipe recipe = Main.recipe[i];
+			// Due to (optional) ore progression changes, some vanilla items should be craftable using regular anvils instead
+			HashSet<int> earlyHardModeAnvilItems = new HashSet<int> 
+			{ 
+				ItemID.AngelWings,
+				ItemID.BatWings,
+				ItemID.BeeWings,
+				ItemID.BoneWings,
+				ItemID.DemonWings,
+				ItemID.FairyWings,
+				ItemID.FrozenWings,
+				ItemID.HarpyWings,
+				ItemID.BluePhaseblade,
+				ItemID.GreenPhaseblade,
+				ItemID.OrangePhaseblade,
+				ItemID.PurplePhaseblade,
+				ItemID.RedPhaseblade,
+				ItemID.WhitePhaseblade,
+				ItemID.YellowPhaseblade,
+				ItemID.Chik,
+				ItemID.CoolWhip,
+				ItemID.CrystalBullet,
+				ItemID.CursedArrow,
+				ItemID.CursedBullet,
+				ItemID.DaoofPow,
+				ItemID.HolyArrow,
+				ItemID.IchorArrow,
+				ItemID.MeteorStaff,
+				ItemID.OnyxBlaster,
+				ItemID.SkyFracture,
+				ItemID.SpiritFlame,
+				ItemID.MechanicalWorm,
+				ItemID.MechanicalEye,
+				ItemID.MechanicalSkull
+			};
 
-                    // If recipe results in FrostHelmet and the recipe used TitaniumBar as an ingredient
-                    if (recipe.HasResult(ItemID.FrostHelmet) && recipe.TryGetIngredient(ItemID.TitaniumBar, out Item titaniumBar))
-                    {
-                        recipe.RemoveIngredient(titaniumBar); // Remove the ingredient
-                        recipe.AddIngredient(ModContent.ItemType<FrostBar>(), 10); // Replace it
-                    }
-                    else if (recipe.HasResult(ItemID.FrostHelmet) && recipe.TryGetIngredient(ItemID.AdamantiteBar, out Item adamantiteBar))
-                    {
-                        recipe.DisableRecipe(); // Here just disable the alt recipe, this mod only has one recipe for this armor
-                    }
+			for (int i = 0; i < Recipe.numRecipes; i++)
+			{
+				Recipe recipe = Main.recipe[i];
 
-                    else if (recipe.HasResult(ItemID.FrostBreastplate) && recipe.TryGetIngredient(ItemID.TitaniumBar, out titaniumBar))
-                    {
-                        recipe.RemoveIngredient(titaniumBar);
-                        recipe.AddIngredient(ModContent.ItemType<FrostBar>(), 20);
-                    }
-                    else if (recipe.HasResult(ItemID.FrostBreastplate) && recipe.TryGetIngredient(ItemID.AdamantiteBar, out adamantiteBar))
-                    {
-                        recipe.DisableRecipe();
-                    }
+				// The player can disable these changes if they want to in the mod configs
+				if (ModContent.GetInstance<ServerSidedToggles>().ModifiedRecipesToggle)
+				{
+					// If recipe results in FrostHelmet and the recipe used TitaniumBar as an ingredient
+					if (recipe.HasResult(ItemID.FrostHelmet) && recipe.TryGetIngredient(ItemID.TitaniumBar, out Item titaniumBar))
+					{
+						recipe.RemoveIngredient(titaniumBar); // Remove the ingredient
+						recipe.AddIngredient(ModContent.ItemType<FrostBar>(), 10); // Replace it
+					}
+					else if (recipe.HasResult(ItemID.FrostHelmet) && recipe.TryGetIngredient(ItemID.AdamantiteBar, out Item adamantiteBar))
+					{
+						recipe.DisableRecipe(); // Here just disable the alt recipe, this mod only has one recipe for this armor
+					}
 
-                    else if (recipe.HasResult(ItemID.FrostLeggings) && recipe.TryGetIngredient(ItemID.TitaniumBar, out titaniumBar))
-                    {
-                        recipe.RemoveIngredient(titaniumBar);
-                        recipe.AddIngredient(ModContent.ItemType<FrostBar>(), 16);
-                    }
-                    else if (recipe.HasResult(ItemID.FrostLeggings) && recipe.TryGetIngredient(ItemID.AdamantiteBar, out adamantiteBar))
-                    {
-                        recipe.DisableRecipe();
-                    }
-                }
-            }
-        }
-    }
+					else if (recipe.HasResult(ItemID.FrostBreastplate) && recipe.TryGetIngredient(ItemID.TitaniumBar, out titaniumBar))
+					{
+						recipe.RemoveIngredient(titaniumBar);
+						recipe.AddIngredient(ModContent.ItemType<FrostBar>(), 20);
+					}
+					else if (recipe.HasResult(ItemID.FrostBreastplate) && recipe.TryGetIngredient(ItemID.AdamantiteBar, out adamantiteBar))
+					{
+						recipe.DisableRecipe();
+					}
+
+					else if (recipe.HasResult(ItemID.FrostLeggings) && recipe.TryGetIngredient(ItemID.TitaniumBar, out titaniumBar))
+					{
+						recipe.RemoveIngredient(titaniumBar);
+						recipe.AddIngredient(ModContent.ItemType<FrostBar>(), 16);
+					}
+					else if (recipe.HasResult(ItemID.FrostLeggings) && recipe.TryGetIngredient(ItemID.AdamantiteBar, out adamantiteBar))
+					{
+						recipe.DisableRecipe();
+					}
+				}
+
+				if (earlyHardModeAnvilItems.Contains(recipe.createItem.type))
+				{
+					recipe.RemoveTile(TileID.MythrilAnvil);
+					recipe.AddTile(TileID.Anvils);
+				}
+			}
+		}
+	}
 }

--- a/Content/Items/Armor/DraconicChestplate.cs
+++ b/Content/Items/Armor/DraconicChestplate.cs
@@ -33,13 +33,13 @@ namespace AssortedAdditions.Content.Items.Armor
             Recipe recipe = CreateRecipe();
             recipe.AddIngredient(ModContent.ItemType<DragonScale>(), 12);
             recipe.AddIngredient(ItemID.PalladiumBar, 24);
-            recipe.AddTile(TileID.MythrilAnvil);
+            recipe.AddTile(TileID.Anvils);
             recipe.Register();
 
             Recipe recipe2 = CreateRecipe();
             recipe2.AddIngredient(ModContent.ItemType<DragonScale>(), 12);
             recipe2.AddIngredient(ItemID.CobaltBar, 24);
-            recipe2.AddTile(TileID.MythrilAnvil);
+            recipe2.AddTile(TileID.Anvils);
             recipe2.Register();
         }
     }

--- a/Content/Items/Armor/DraconicGreaves.cs
+++ b/Content/Items/Armor/DraconicGreaves.cs
@@ -34,13 +34,13 @@ namespace AssortedAdditions.Content.Items.Armor
             Recipe recipe = CreateRecipe();
             recipe.AddIngredient(ModContent.ItemType<DragonScale>(), 9);
             recipe.AddIngredient(ItemID.PalladiumBar, 18);
-            recipe.AddTile(TileID.MythrilAnvil);
+            recipe.AddTile(TileID.Anvils);
             recipe.Register();
 
             Recipe recipe2 = CreateRecipe();
             recipe2.AddIngredient(ModContent.ItemType<DragonScale>(), 9);
             recipe2.AddIngredient(ItemID.CobaltBar, 18);
-            recipe2.AddTile(TileID.MythrilAnvil);
+            recipe2.AddTile(TileID.Anvils);
             recipe2.Register();
         }
     }

--- a/Content/Items/Armor/DraconicHat.cs
+++ b/Content/Items/Armor/DraconicHat.cs
@@ -57,13 +57,13 @@ namespace AssortedAdditions.Content.Items.Armor
             Recipe recipe = CreateRecipe();
             recipe.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe.AddIngredient(ItemID.PalladiumBar, 12);
-            recipe.AddTile(TileID.MythrilAnvil);
+            recipe.AddTile(TileID.Anvils);
             recipe.Register();
 
             Recipe recipe2 = CreateRecipe();
             recipe2.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe2.AddIngredient(ItemID.CobaltBar, 12);
-            recipe2.AddTile(TileID.MythrilAnvil);
+            recipe2.AddTile(TileID.Anvils);
             recipe2.Register();
         }
     }

--- a/Content/Items/Armor/DraconicHelmet.cs
+++ b/Content/Items/Armor/DraconicHelmet.cs
@@ -55,13 +55,13 @@ namespace AssortedAdditions.Content.Items.Armor
             Recipe recipe = CreateRecipe();
             recipe.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe.AddIngredient(ItemID.PalladiumBar, 12);
-            recipe.AddTile(TileID.MythrilAnvil);
+            recipe.AddTile(TileID.Anvils);
             recipe.Register();
 
             Recipe recipe2 = CreateRecipe();
             recipe2.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe2.AddIngredient(ItemID.CobaltBar, 12);
-            recipe2.AddTile(TileID.MythrilAnvil);
+            recipe2.AddTile(TileID.Anvils);
             recipe2.Register();
         }
     }

--- a/Content/Items/Armor/DraconicHood.cs
+++ b/Content/Items/Armor/DraconicHood.cs
@@ -57,13 +57,13 @@ namespace AssortedAdditions.Content.Items.Armor
             Recipe recipe = CreateRecipe();
             recipe.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe.AddIngredient(ItemID.PalladiumBar, 12);
-            recipe.AddTile(TileID.MythrilAnvil);
+            recipe.AddTile(TileID.Anvils);
             recipe.Register();
 
             Recipe recipe2 = CreateRecipe();
             recipe2.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe2.AddIngredient(ItemID.CobaltBar, 12);
-            recipe2.AddTile(TileID.MythrilAnvil);
+            recipe2.AddTile(TileID.Anvils);
             recipe2.Register();
         }
     }

--- a/Content/Items/Armor/DraconicMask.cs
+++ b/Content/Items/Armor/DraconicMask.cs
@@ -58,13 +58,13 @@ namespace AssortedAdditions.Content.Items.Armor
             Recipe recipe = CreateRecipe();
             recipe.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe.AddIngredient(ItemID.PalladiumBar, 12);
-            recipe.AddTile(TileID.MythrilAnvil);
+            recipe.AddTile(TileID.Anvils);
             recipe.Register();
 
             Recipe recipe2 = CreateRecipe();
             recipe2.AddIngredient(ModContent.ItemType<DragonScale>(), 6);
             recipe2.AddIngredient(ItemID.CobaltBar, 12);
-            recipe2.AddTile(TileID.MythrilAnvil);
+            recipe2.AddTile(TileID.Anvils);
             recipe2.Register();
         }
     }

--- a/Content/Items/Weapons/Magic/DraconicTome.cs
+++ b/Content/Items/Weapons/Magic/DraconicTome.cs
@@ -4,6 +4,8 @@ using Terraria.ModLoader;
 using Terraria;
 using Microsoft.Xna.Framework;
 using AssortedAdditions.Content.Projectiles.MagicProj;
+using AssortedAdditions.Content.Items.Misc;
+using AssortedAdditions.Content.Tiles.CraftingStations;
 
 namespace AssortedAdditions.Content.Items.Weapons.Magic
 {
@@ -60,5 +62,15 @@ namespace AssortedAdditions.Content.Items.Weapons.Magic
 
             return true;
         }
+
+        public override void AddRecipes()
+        {
+            Recipe.Create(ModContent.ItemType<DraconicTome>())
+                .AddIngredient(ItemID.SpellTome)
+                .AddIngredient(ModContent.ItemType<MagicEssence>(), 6)
+                .AddIngredient(ModContent.ItemType<DragonScale>(), 6)
+                .AddTile(ModContent.TileType<MagicWorkbenchTile>())
+                .Register();
+		}
     }
 }

--- a/Content/Items/Weapons/Magic/DustbringerStaff.cs
+++ b/Content/Items/Weapons/Magic/DustbringerStaff.cs
@@ -32,5 +32,10 @@ namespace AssortedAdditions.Content.Items.Weapons.Magic
         }
 
         public override Vector2? HoldoutOffset() => new(-15, 0); // Alligns the sprite properly
-    }
+
+		public override void ModifyShootStats(Player player, ref Vector2 position, ref Vector2 velocity, ref int type, ref int damage, ref float knockback)
+		{
+            position = new(position.X, position.Y - 20);
+		}
+	}
 }

--- a/Content/Items/Weapons/Melee/DraconicBlade.cs
+++ b/Content/Items/Weapons/Melee/DraconicBlade.cs
@@ -1,8 +1,8 @@
-﻿using AssortedAdditions.Content.Projectiles.MeleeProj;
+﻿using AssortedAdditions.Content.Items.Misc;
+using AssortedAdditions.Content.Projectiles.MeleeProj;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.DataStructures;
-using Terraria.GameContent.Creative;
 using Terraria.ID;
 using Terraria.ModLoader;
 
@@ -78,5 +78,14 @@ namespace AssortedAdditions.Content.Items.Weapons.Melee
         {
             target.AddBuff(BuffID.OnFire, 120);
         }
-    }
+
+		public override void AddRecipes()
+		{
+			Recipe.Create(ModContent.ItemType<DraconicBlade>())
+	            .AddIngredient(ItemID.PalladiumBar, 10)
+	            .AddIngredient(ModContent.ItemType<DragonScale>(), 6)
+	            .AddTile(TileID.Anvils)
+	            .Register();
+		}
+	}
 }

--- a/Content/Items/Weapons/Ranged/DraconicBow.cs
+++ b/Content/Items/Weapons/Ranged/DraconicBow.cs
@@ -5,6 +5,7 @@ using Terraria;
 using Microsoft.Xna.Framework;
 using Terraria.DataStructures;
 using AssortedAdditions.Content.Projectiles.RangedProj;
+using AssortedAdditions.Content.Items.Misc;
 
 namespace AssortedAdditions.Content.Items.Weapons.Ranged
 {
@@ -64,5 +65,14 @@ namespace AssortedAdditions.Content.Items.Weapons.Ranged
         {
             type = ModContent.ProjectileType<DraconicBowProj>();
         }
-    }
+
+		public override void AddRecipes()
+		{
+			Recipe.Create(ModContent.ItemType<DraconicBow>())
+				.AddIngredient(ItemID.PalladiumBar, 10)
+				.AddIngredient(ModContent.ItemType<DragonScale>(), 6)
+				.AddTile(TileID.Anvils)
+				.Register();
+		}
+	}
 }

--- a/Content/Items/Weapons/Ranged/IceBlaster.cs
+++ b/Content/Items/Weapons/Ranged/IceBlaster.cs
@@ -47,7 +47,7 @@ namespace AssortedAdditions.Content.Items.Weapons.Ranged
             Recipe recipe = CreateRecipe();
             recipe.AddIngredient(ItemID.FrostCore, 1);
             recipe.AddIngredient(ItemID.PhoenixBlaster, 1);
-            recipe.AddTile(TileID.MythrilAnvil);
+            recipe.AddTile(TileID.Anvils);
             recipe.Register();
         }
     }

--- a/Content/Items/Weapons/Summon/DragonStaff.cs
+++ b/Content/Items/Weapons/Summon/DragonStaff.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework;
 using Terraria.DataStructures;
 using AssortedAdditions.Content.Buffs;
 using AssortedAdditions.Content.Projectiles.SummonProj;
+using AssortedAdditions.Content.Items.Misc;
 
 namespace AssortedAdditions.Content.Items.Weapons.Summon;
 
@@ -45,6 +46,14 @@ public class DragonStaff : ModItem
         projectile.originalDamage = Item.damage;
 
         return false;
-
     }
+
+	public override void AddRecipes()
+	{
+		Recipe.Create(ModContent.ItemType<DragonStaff>())
+			.AddIngredient(ItemID.PalladiumBar, 10)
+			.AddIngredient(ModContent.ItemType<DragonScale>(), 6)
+			.AddTile(TileID.Anvils)
+			.Register();
+	}
 }

--- a/Content/NPCs/BossTheHaunt/TheHaunt.cs
+++ b/Content/NPCs/BossTheHaunt/TheHaunt.cs
@@ -265,9 +265,9 @@ namespace AssortedAdditions.Content.NPCs.BossTheHaunt
 					direction.Normalize();
 					direction *= 4f;
 
-					// Spawn up to three, rotate each ones basic velocity
-					float numberProjectiles = 6; // or maybe just 3 and 60 degrees
-					float rotation = MathHelper.ToRadians(180);
+					
+					float numberProjectiles = 6; // Spawn up to X
+					float rotation = MathHelper.ToRadians(180); // rotation for start velocity
 
 					// Spawn the projectiles
 					for (int i = 0; i < numberProjectiles; i++)

--- a/Helpers/HelperMethods.cs
+++ b/Helpers/HelperMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using Terraria;
 
@@ -9,6 +10,17 @@ namespace AssortedAdditions.Helpers
 	/// </summary>
 	public class HelperMethods
 	{
+		/// <summary>
+		/// Checks if at least X amount of booleans are true in the given booleans
+		/// </summary>
+		/// <param name="atLeast">How many booleans should be true at least</param>
+		/// <param name="booleans">The booleans to check</param>
+		/// <returns>True if enough booleans are true, false if not</returns>
+		public static bool AtLeastTrue(int atLeast, params bool[] booleans)
+		{
+			return booleans.Count(b => b) >= atLeast;
+		}
+
 		/// <summary>
 		/// Converts seconds to ticks
 		/// </summary>

--- a/build.txt
+++ b/build.txt
@@ -1,3 +1,3 @@
 displayName = Assorted Additions
 author = Jesse.
-version = 0.1.1.6
+version = 0.1.1.7

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,10 @@
-[B]v0.1.1.6[/B]
+[B]v0.1.1.7[/B]
 
 [LIST]
-[*] Fixed minions not triggering the Fire Cracker explosion properly
+[*] Changes to hardmode ore progression: Mythril/Orichalcum can be mined after defeating Fire Dragon or any mech boss, Adamantite/Titanium can be mined after defeating at least two mech bosses. (Can still be toggled off)
+[*] Mech boss summoning items as well as a bunch of early hardmode items can now be crafted at regular anvils
+[*] Celestial Pillar enemies now drop fragments
+[*] Fire Dragon weapon drops can now also be crafted
+[*] Improved Dust Bringer Staff Projectile logic
 [/LIST]
 


### PR DESCRIPTION
- Changes to hardmode ore progression: Mythril/Orichalcum can be mined after defeating Fire Dragon or any mech boss, Adamantite/Titanium can be mined after defeating at least two mech bosses. (Can still be toggled off)
- Mech boss summoning items as well as a bunch of early hardmode items can now be crafted at regular anvils
- Celestial Pillar enemies now drop fragments
- Fire Dragon weapon drops can now also be crafted
- Improved Dust Bringer Staff Projectile logic