### PR TITLE
v0.1.1.8

### DIFF
--- a/Common/GlobalItems/ModifiedCrates.cs
+++ b/Common/GlobalItems/ModifiedCrates.cs
@@ -1,0 +1,91 @@
+﻿using AssortedAdditions.Content.Items.Accessories;
+using AssortedAdditions.Content.Items.Accessories.Runes;
+using AssortedAdditions.Content.Items.Misc;
+using AssortedAdditions.Content.Items.Placeables.Ores;
+using AssortedAdditions.Content.Items.Weapons.Magic;
+using AssortedAdditions.Content.Items.Weapons.Melee;
+using AssortedAdditions.Content.Items.Weapons.Ranged;
+using AssortedAdditions.Content.Items.Weapons.Summon;
+using Terraria;
+using Terraria.GameContent.ItemDropRules;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace AssortedAdditions.Common.GlobalItems
+{
+	internal class ModifiedCrates : GlobalItem
+	{
+		public override void ModifyItemLoot(Item item, ItemLoot itemLoot)
+		{
+			int itemType = item.type;
+
+			LeadingConditionRule hardmode = new LeadingConditionRule(Condition.Hardmode.ToDropCondition(ShowItemDropInUI.Always));
+
+			switch (itemType)
+			{
+				case ItemID.WoodenCrate:
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<MinersRing>(), 20));
+				break;
+
+				case ItemID.IronCrate:
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<BlankRune>(), 15));
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<StoneWand>(), 15));
+				break;
+
+				case ItemID.GoldenCrate:
+				case ItemID.GoldenCrateHard:
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<RuneOfSpelunking>(), 20));
+				break;
+
+				case ItemID.FloatingIslandFishingCrate:
+				case ItemID.FloatingIslandFishingCrateHard:
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<HangGlider>(), 8));
+				break;
+
+				case ItemID.DungeonFishingCrate:
+				case ItemID.DungeonFishingCrateHard:
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<RuneOfMovement>(), 8));
+				break;
+
+				case ItemID.OasisCrate:
+				case ItemID.OasisCrateHard:
+					int[] desertMimicItems = { ModContent.ItemType<DesertsFury>(), ModContent.ItemType<DustbringerStaff>(), ModContent.ItemType<DesertBlaster>(), ModContent.ItemType<SunScepter>() };
+					hardmode.OnSuccess(ItemDropRule.OneFromOptions(2, desertMimicItems));
+					itemLoot.Add(hardmode);
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<Dunerang>(), 5));
+				break;
+
+				case ItemID.JungleFishingCrate:
+				case ItemID.JungleFishingCrateHard:
+					int[] jungleMimicItems = { ModContent.ItemType<PetalBlade>(), ModContent.ItemType<SporeRod>(), ModContent.ItemType<JungleChakram>(), ModContent.ItemType<BlossomLash>() };
+					hardmode.OnSuccess(ItemDropRule.OneFromOptions(2, jungleMimicItems));
+					itemLoot.Add(hardmode);
+				break;
+
+				case ItemID.OceanCrate:
+					itemLoot.Add(ItemDropRule.Common(ModContent.ItemType<ShellHorn>(), 5));
+				break;
+			}
+
+			// *** ULTIMATE SKYBLOCK COMPATIBILITY STUFF ***
+			if (ModLoader.TryGetMod("UltimateSkyblock", out Mod UltimateSkyblock))
+			{
+				switch (itemType)
+				{
+					case ItemID.FrozenCrate:
+					case ItemID.FrozenCrateHard:
+						itemLoot.Add(ItemDropRule.ByCondition(Condition.DownedMechBossAny.ToDropCondition(ShowItemDropInUI.Always), ModContent.ItemType<Permafrost>(), 5, 20, 35));
+						itemLoot.Add(ItemDropRule.ByCondition(Condition.DownedMechBossAny.ToDropCondition(ShowItemDropInUI.Always), ModContent.ItemType<FrostBar>(), 12, 6, 16));
+						itemLoot.Add(ItemDropRule.ByCondition(Condition.DownedMechBossAny.ToDropCondition(ShowItemDropInUI.Always), ModContent.ItemType<IceEssence>(), 8, 3, 4));
+					break;
+
+					case ItemID.OasisCrate:
+					case ItemID.OasisCrateHard:
+						itemLoot.Add(ItemDropRule.ByCondition(Condition.DownedEowOrBoc.ToDropCondition(ShowItemDropInUI.Always), ModContent.ItemType<DuneOre>(), 5, 20, 35));
+						itemLoot.Add(ItemDropRule.ByCondition(Condition.DownedEowOrBoc.ToDropCondition(ShowItemDropInUI.Always), ModContent.ItemType<DuneBar>(), 12, 6, 16));
+					break;
+				}
+			}
+		}
+	}
+}

--- a/Common/GlobalNPCs/PermafrostGeneration.cs
+++ b/Common/GlobalNPCs/PermafrostGeneration.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.WorldBuilding;
 
@@ -13,7 +14,9 @@ namespace AssortedAdditions.Common.GlobalNPCs
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
             // Check if the entity is one of the mech bosses
-            if (entity.type == NPCID.Retinazer || entity.type == NPCID.Spazmatism || entity.type == NPCID.TheDestroyer || entity.type == NPCID.SkeletronPrime)
+            // TODO: now the permafrost spawns if spazmatism is defeated without killing retinazer
+            // should only spawn after defeating both, removed check for retinazer since then it would spawn twice
+            if (entity.type == NPCID.Spazmatism || entity.type == NPCID.TheDestroyer || entity.type == NPCID.SkeletronPrime)
             {
                 return true;
             }
@@ -40,7 +43,7 @@ namespace AssortedAdditions.Common.GlobalNPCs
                     }
                 }
 
-                Main.NewText("The ice caverns get colder...", Color.Blue);
+                Main.NewText(Language.GetTextValue("Mods.AssortedAdditions.ChatMessages.Permafrost"), Color.Blue);
             }
         }
     }

--- a/Common/GlobalNPCs/PermafrostGeneration.cs
+++ b/Common/GlobalNPCs/PermafrostGeneration.cs
@@ -1,4 +1,5 @@
 ﻿using AssortedAdditions.Content.Tiles;
+using AssortedAdditions.Helpers;
 using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
@@ -14,9 +15,7 @@ namespace AssortedAdditions.Common.GlobalNPCs
         public override bool AppliesToEntity(NPC entity, bool lateInstantiation)
         {
             // Check if the entity is one of the mech bosses
-            // TODO: now the permafrost spawns if spazmatism is defeated without killing retinazer
-            // should only spawn after defeating both, removed check for retinazer since then it would spawn twice
-            if (entity.type == NPCID.Spazmatism || entity.type == NPCID.TheDestroyer || entity.type == NPCID.SkeletronPrime)
+            if (entity.type == NPCID.Retinazer || entity.type == NPCID.Spazmatism || entity.type == NPCID.TheDestroyer || entity.type == NPCID.SkeletronPrime)
             {
                 return true;
             }
@@ -29,6 +28,18 @@ namespace AssortedAdditions.Common.GlobalNPCs
             // If none of the mech bosses have been defeated yet, generate Permafrost
             if (!NPC.downedMechBossAny)
             {
+                // Special check for the twins to prevent permafrost generating twice
+                if(npc.type == NPCID.Retinazer || npc.type == NPCID.Spazmatism)
+                {
+                    // Basically check if the other twin is still alive, works in combination with the downedMechBossAny
+                    int otherTwin = npc.type == NPCID.Retinazer ? NPCID.Spazmatism : NPCID.Retinazer;
+					Main.NewText(otherTwin);
+					if (HelperMethods.CountNPCs(otherTwin, 1) > 0)
+                    {
+                        return;
+                    }
+                }
+
                 int maxtoSpawn = (int)(Main.maxTilesX * Main.maxTilesY * 0.0006); // Adjusting this last number increases/decreases amount
                 for (int i = 0; i < maxtoSpawn; i++)
                 {

--- a/Common/GlobalNPCs/PermafrostGeneration.cs
+++ b/Common/GlobalNPCs/PermafrostGeneration.cs
@@ -25,6 +25,11 @@ namespace AssortedAdditions.Common.GlobalNPCs
 
         public override void OnKill(NPC npc)
         {
+            if(ModLoader.TryGetMod("UltimateSkyblock", out Mod UltimateSkyblock))
+            {
+                return; // No point in running this in the skyblock mod
+            }
+
             // If none of the mech bosses have been defeated yet, generate Permafrost
             if (!NPC.downedMechBossAny)
             {
@@ -33,7 +38,6 @@ namespace AssortedAdditions.Common.GlobalNPCs
                 {
                     // Basically check if the other twin is still alive, works in combination with the downedMechBossAny
                     int otherTwin = npc.type == NPCID.Retinazer ? NPCID.Spazmatism : NPCID.Retinazer;
-					Main.NewText(otherTwin);
 					if (HelperMethods.CountNPCs(otherTwin, 1) > 0)
                     {
                         return;

--- a/Common/GlobalTiles/HardmodeOreProgression.cs
+++ b/Common/GlobalTiles/HardmodeOreProgression.cs
@@ -3,6 +3,7 @@ using AssortedAdditions.Common.Systems;
 using AssortedAdditions.Helpers;
 using Microsoft.Xna.Framework;
 using Terraria;
+using Terraria.Chat;
 using Terraria.ID;
 using Terraria.Localization;
 using Terraria.ModLoader;
@@ -15,6 +16,7 @@ namespace AssortedAdditions.Common.GlobalTiles
 	// Adamantite/Titanium after any two mech bosses
 	internal class HardmodeOreProgression : GlobalTile
 	{
+		private int popupMsg = -1;
 		public override bool CanKillTile(int i, int j, int type, ref bool blockDamaged)
 		{
 			// The player can toggle this on/off if they want to use vanilla progression
@@ -30,7 +32,11 @@ namespace AssortedAdditions.Common.GlobalTiles
 						}
 						else
 						{
-							PopupText.NewText(new AdvancedPopupRequest
+							if(popupMsg != -1)
+							{
+								Main.popupText[popupMsg].active = false;
+							}
+							popupMsg = PopupText.NewText(new AdvancedPopupRequest
 							{
 								Text = Language.GetTextValue("Mods.AssortedAdditions.PopupMessages.HardmodeOre"),
 								Color = Color.Red,
@@ -52,8 +58,12 @@ namespace AssortedAdditions.Common.GlobalTiles
 							string message = NPC.downedMechBossAny 
 								? Language.GetTextValue("Mods.AssortedAdditions.PopupMessages.HardmodeOre") 
 								: Language.GetTextValue("Mods.AssortedAdditions.PopupMessages.HardmodeOreAlt");
-							
-							PopupText.NewText(new AdvancedPopupRequest
+
+							if (popupMsg != -1)
+							{
+								Main.popupText[popupMsg].active = false;
+							}
+							popupMsg = PopupText.NewText(new AdvancedPopupRequest
 							{
 								Text = message,
 								Color = Color.Red,
@@ -71,6 +81,19 @@ namespace AssortedAdditions.Common.GlobalTiles
 			}
 
 			return base.CanKillTile(i, j, type, ref blockDamaged);
+		}
+	}
+
+	public class HardmodeOreProgressionMessage : GlobalNPC
+	{
+		public override bool AppliesToEntity(NPC entity, bool lateInstantiation) => entity.type == NPCID.WallofFlesh;
+
+		public override void OnKill(NPC npc)
+		{
+			if(!Main.hardMode && ServerSidedToggles.Instance.HardmodeOreProgressionToggle)
+			{
+				ChatHelper.BroadcastChatMessage(NetworkText.FromKey("Mods.AssortedAdditions.ChatMessages.HardmodeOres"), Color.DarkOrange);
+			}
 		}
 	}
 }

--- a/Common/GlobalTiles/HardmodeOreProgression.cs
+++ b/Common/GlobalTiles/HardmodeOreProgression.cs
@@ -1,43 +1,76 @@
 ﻿using AssortedAdditions.Common.Configs;
 using AssortedAdditions.Common.Systems;
 using AssortedAdditions.Helpers;
+using Microsoft.Xna.Framework;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 
 namespace AssortedAdditions.Common.GlobalTiles
 {
-    // The hardmode ore progression is different. Only palladium/cobalt can be mined after Wall of Flesh
-    // Orichalcum/Mythril can be mined after defeating one mech boss
-    // Adamantite/Titanium can be mined after defeating The Destroyer and The Twins
-    internal class HardmodeOreProgression : GlobalTile
-    {
-        public override bool CanKillTile(int i, int j, int type, ref bool blockDamaged)
-        {
-            // The player can toggle this on/off if they want to use vanilla progression
-            if (ModContent.GetInstance<ServerSidedToggles>().HardmodeOreProgressionToggle)
-            {
-                switch (type)
-                {
-                    case TileID.Mythril:
-                        return NPC.downedMechBossAny || DownedBossSystem.downedFireDragon;
+	// The hardmode ore progression is different.
+	// Palladium/Cobalt after wall of flesh
+	// Orichalcum/Mythril after defeating one mech boss or the fire dragon
+	// Adamantite/Titanium after any two mech bosses
+	internal class HardmodeOreProgression : GlobalTile
+	{
+		public override bool CanKillTile(int i, int j, int type, ref bool blockDamaged)
+		{
+			// The player can toggle this on/off if they want to use vanilla progression
+			if (ModContent.GetInstance<ServerSidedToggles>().HardmodeOreProgressionToggle)
+			{
+				switch (type)
+				{
+					case TileID.Mythril:
+					case TileID.Orichalcum:
+						if (NPC.downedMechBossAny || DownedBossSystem.downedFireDragon)
+						{
+							return true;
+						}
+						else
+						{
+							PopupText.NewText(new AdvancedPopupRequest
+							{
+								Text = Language.GetTextValue("Mods.AssortedAdditions.PopupMessages.HardmodeOre"),
+								Color = Color.Red,
+								DurationInFrames = 90,
+								Velocity = Vector2.Zero
+							}, new Vector2(i * 16, j * 16));
 
-                    case TileID.Orichalcum:
-                        return NPC.downedMechBossAny || DownedBossSystem.downedFireDragon;
+							return false;
+						}
 
-                    case TileID.Adamantite:
-						return HelperMethods.AtLeastTrue(2, NPC.downedMechBoss1, NPC.downedMechBoss2, NPC.downedMechBoss3);
-
-
+					case TileID.Adamantite:
 					case TileID.Titanium:
-						return HelperMethods.AtLeastTrue(2, NPC.downedMechBoss1, NPC.downedMechBoss2, NPC.downedMechBoss3);
+						if (HelperMethods.AtLeastTrue(2, NPC.downedMechBoss1, NPC.downedMechBoss2, NPC.downedMechBoss3))
+						{
+							return true;
+						}
+						else
+						{
+							string message = NPC.downedMechBossAny 
+								? Language.GetTextValue("Mods.AssortedAdditions.PopupMessages.HardmodeOre") 
+								: Language.GetTextValue("Mods.AssortedAdditions.PopupMessages.HardmodeOreAlt");
+							
+							PopupText.NewText(new AdvancedPopupRequest
+							{
+								Text = message,
+								Color = Color.Red,
+								DurationInFrames = 90,
+								Velocity = Vector2.Zero
+							}, new Vector2(i * 16, j * 16));
+
+							return false;
+						}
+
 
 					default:
-                        break;
-                }
-            }
+						break;
+				}
+			}
 
-            return base.CanKillTile(i, j, type, ref blockDamaged);
-        }
-    }
+			return base.CanKillTile(i, j, type, ref blockDamaged);
+		}
+	}
 }

--- a/Common/Systems/ModifiedRecipes.cs
+++ b/Common/Systems/ModifiedRecipes.cs
@@ -52,6 +52,7 @@ namespace AssortedAdditions.Common.Systems
 				Recipe recipe = Main.recipe[i];
 
 				// The player can disable these changes if they want to in the mod configs
+				// Changes affected by the config could potentially be bad (e.g., frost armor not craftable if permafrost can't generate)
 				if (ModContent.GetInstance<ServerSidedToggles>().ModifiedRecipesToggle)
 				{
 					// If recipe results in FrostHelmet and the recipe used TitaniumBar as an ingredient
@@ -86,6 +87,7 @@ namespace AssortedAdditions.Common.Systems
 					}
 				}
 
+				// Outside of config toggle on purpose, shouldn't cause problems
 				if (earlyHardModeAnvilItems.Contains(recipe.createItem.type))
 				{
 					recipe.RemoveTile(TileID.MythrilAnvil);

--- a/Content/NPCs/BossTheHaunt/Hauntling.cs
+++ b/Content/NPCs/BossTheHaunt/Hauntling.cs
@@ -194,7 +194,7 @@ namespace AssortedAdditions.Content.NPCs.BossTheHaunt
 
 			// Redraw the projectile with the color not influenced by light
 			Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, NPC.height * 0.5f);
-			for (int k = 0; k < NPC.oldPos.Length; k++)
+			for (int k = NPC.oldPos.Length - 1; k > 0; k--)
 			{
 				Vector2 drawPos = NPC.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, NPC.gfxOffY);
 				Color color = NPC.GetAlpha(drawColor) * ((NPC.oldPos.Length - k) / (float)NPC.oldPos.Length);

--- a/Content/NPCs/BossTheHaunt/TheHaunt.cs
+++ b/Content/NPCs/BossTheHaunt/TheHaunt.cs
@@ -642,7 +642,7 @@ namespace AssortedAdditions.Content.NPCs.BossTheHaunt
 
 			// Redraw the projectile with the color not influenced by light
 			Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, NPC.height * 0.5f);
-			for (int k = 0; k < NPC.oldPos.Length; k++)
+			for (int k = NPC.oldPos.Length - 1; k > 0; k--)
 			{
 				Vector2 drawPos = NPC.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, NPC.gfxOffY);
 				Color color = NPC.GetAlpha(drawColor) * ((NPC.oldPos.Length - k) / (float)NPC.oldPos.Length);

--- a/Content/NPCs/CursedPickaxe.cs
+++ b/Content/NPCs/CursedPickaxe.cs
@@ -7,6 +7,8 @@ using Microsoft.Xna.Framework;
 using AssortedAdditions.Content.Items.Misc;
 using AssortedAdditions.Content.Items.Placeables.Banners;
 using AssortedAdditions.Common.Configs;
+using Terraria.ModLoader.Utilities;
+using AssortedAdditions.Content.Items.Placeables.Ores;
 
 namespace AssortedAdditions.Content.NPCs
 {
@@ -49,12 +51,20 @@ namespace AssortedAdditions.Content.NPCs
         // and only in the underground ice biome
         public override float SpawnChance(NPCSpawnInfo spawnInfo)
         {
+            float baseChance = 0.004f;
+			float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f 
+                ? ServerSidedToggles.Instance.CursedPickaxeSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
+			
             if (NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow && spawnInfo.Player.ZoneRockLayerHeight)
             {
-                float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f
-                    ? ServerSidedToggles.Instance.CursedPickaxeSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
-
-				return 0.004f * multiplier;
+				return baseChance * multiplier;
+            }
+            else if (NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow)
+            {
+                if(ModLoader.TryGetMod("UltimateSkyblock", out Mod UltimateSkyblock))
+                {
+                    return 10 * baseChance * multiplier;
+				}
             }
 
             return 0f;

--- a/Content/NPCs/FrostWraith.cs
+++ b/Content/NPCs/FrostWraith.cs
@@ -64,12 +64,20 @@ namespace AssortedAdditions.Content.NPCs
         // and only in the underground ice biome
         public override float SpawnChance(NPCSpawnInfo spawnInfo)
         {
-            if (NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow && spawnInfo.Player.ZoneRockLayerHeight)
-            {
-				float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f 
-                    ? ServerSidedToggles.Instance.FrostWraithSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
+            float baseChance = 0.1f;
+			float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f
+                ? ServerSidedToggles.Instance.FrostWraithSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
 
-				return SpawnCondition.Cavern.Chance * 0.1f * multiplier;
+			if (NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow && spawnInfo.Player.ZoneRockLayerHeight)
+            {
+				return SpawnCondition.Cavern.Chance * baseChance * multiplier;
+            }
+            else if(NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow && !Main.dayTime)
+            {
+                if(ModLoader.TryGetMod("UltimateSkyblock", out Mod UltimateSkyblock))
+                {
+                    return 2f * baseChance * multiplier;
+				}
             }
 
             return 0f;

--- a/Content/NPCs/IceGuardian.cs
+++ b/Content/NPCs/IceGuardian.cs
@@ -10,6 +10,7 @@ using Terraria.GameContent.ItemDropRules;
 using Terraria.ID;
 using Terraria.ModLoader;
 using Terraria.ModLoader.Utilities;
+using static Terraria.ModLoader.PlayerDrawLayer;
 
 namespace AssortedAdditions.Content.NPCs
 {
@@ -116,15 +117,22 @@ namespace AssortedAdditions.Content.NPCs
 
         public override float SpawnChance(NPCSpawnInfo spawnInfo)
         {
-            if (NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow && spawnInfo.Player.ZoneRockLayerHeight)
+            float baseChance = 0.05f;
+			float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f
+                ? ServerSidedToggles.Instance.IceGuardianSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
+			if (NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow && spawnInfo.Player.ZoneRockLayerHeight)
             {
-				float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f
-					? ServerSidedToggles.Instance.IceGuardianSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
-
-				return (SpawnCondition.Cavern.Chance * 0.05f) * multiplier;
+                return SpawnCondition.Cavern.Chance * baseChance * multiplier;
             }
+			else if (NPC.downedMechBossAny && spawnInfo.Player.ZoneSnow)
+			{
+				if (ModLoader.TryGetMod("UltimateSkyblock", out Mod UltimateSkyblock))
+				{
+					return baseChance * multiplier;
+				}
+			}
 
-            return 0f;
+			return 0f;
         }
 
         public override void ModifyNPCLoot(NPCLoot npcLoot)

--- a/Content/NPCs/JungleMimic.cs
+++ b/Content/NPCs/JungleMimic.cs
@@ -49,6 +49,13 @@ namespace AssortedAdditions.Content.NPCs
             {
                 return SpawnCondition.UndergroundMimic.Chance;
             }
+            else if (NPC.downedMechBossAny && spawnInfo.Player.ZoneJungle)
+            {
+                if(ModLoader.TryGetMod("UltimateSkyblock", out Mod UltimateSkyblock))
+                {
+                    return 0.015f;
+                }
+            }
 
             return 0f;
         }

--- a/Content/NPCs/PhantomMage.cs
+++ b/Content/NPCs/PhantomMage.cs
@@ -414,7 +414,7 @@ namespace AssortedAdditions.Content.NPCs
 
 			// Redraw the projectile with the color not influenced by light
 			Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, NPC.height * 0.5f);
-			for (int k = 0; k < NPC.oldPos.Length; k++)
+			for (int k = NPC.oldPos.Length - 1; k > 0; k--)
 			{
 				Vector2 drawPos = NPC.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, NPC.gfxOffY);
 				Color color = NPC.GetAlpha(drawColor) * ((NPC.oldPos.Length - k) / (float)NPC.oldPos.Length);

--- a/Content/NPCs/SandstoneMimic.cs
+++ b/Content/NPCs/SandstoneMimic.cs
@@ -50,12 +50,19 @@ namespace AssortedAdditions.Content.NPCs
         // Should only spawn during hardmode and in the underground desert
         public override float SpawnChance(NPCSpawnInfo spawnInfo)
         {
-            if (Main.hardMode && spawnInfo.Player.ZoneUndergroundDesert)
+            float baseChance = 0.05f;
+			float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f
+                ? ServerSidedToggles.Instance.SandstoneMimicSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
+			if (Main.hardMode && spawnInfo.Player.ZoneUndergroundDesert)
             {
-                float multiplier = ServerSidedToggles.Instance.NPCSpawnMultiplier == 1f
-                    ? ServerSidedToggles.Instance.SandstoneMimicSpawnMultiplier : ServerSidedToggles.Instance.NPCSpawnMultiplier;
-
-				return SpawnCondition.DesertCave.Chance * 0.05f * multiplier;
+				return SpawnCondition.DesertCave.Chance * baseChance * multiplier;
+            }
+            else if(Main.hardMode && spawnInfo.Player.ZoneDesert)
+            {
+                if(ModLoader.TryGetMod("UltimateSkyblock", out Mod UltimateSkyblock))
+                {
+                    return baseChance * multiplier;
+                }
             }
 
             return 0f;

--- a/Content/Projectiles/MagicProj/TrueAmberStaffProj.cs
+++ b/Content/Projectiles/MagicProj/TrueAmberStaffProj.cs
@@ -95,7 +95,7 @@ namespace AssortedAdditions.Content.Projectiles.MagicProj
 
 			// Redraw the projectile with the color not influenced by light
 			Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-            for (int k = 0; k < Projectile.oldPos.Length; k++)
+            for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
             {
                 Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
                 Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/MagicProj/TrueEmeraldStaffProj.cs
+++ b/Content/Projectiles/MagicProj/TrueEmeraldStaffProj.cs
@@ -98,7 +98,7 @@ namespace AssortedAdditions.Content.Projectiles.MagicProj
 
             // Redraw the projectile with the color not influenced by light
             Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-            for (int k = 0; k < Projectile.oldPos.Length; k++)
+            for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
             {
                 Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
                 Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/MeleeProj/DraconicBladeProj.cs
+++ b/Content/Projectiles/MeleeProj/DraconicBladeProj.cs
@@ -12,7 +12,7 @@ namespace AssortedAdditions.Content.Projectiles.MeleeProj
     {
         public override void SetStaticDefaults()
         {
-            ProjectileID.Sets.TrailCacheLength[Projectile.type] = 5; // The length of old position to be recorded
+            ProjectileID.Sets.TrailCacheLength[Projectile.type] = 7; // The length of old position to be recorded
             ProjectileID.Sets.TrailingMode[Projectile.type] = 3; // The recording mode
             // Actual trail is drawn in PreDraw()
         }
@@ -52,7 +52,7 @@ namespace AssortedAdditions.Content.Projectiles.MeleeProj
 
             // Redraw the projectile with the color not influenced by light
             Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-            for (int k = 0; k < Projectile.oldPos.Length; k++)
+            for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
             {
                 Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
                 Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/MeleeProj/PwnageProj.cs
+++ b/Content/Projectiles/MeleeProj/PwnageProj.cs
@@ -450,7 +450,7 @@ namespace AssortedAdditions.Content.Projectiles.MeleeProj
 
 				// Redraw the projectile with the color not influenced by light
 				Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-				for (int k = 0; k < Projectile.oldPos.Length; k++)
+				for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
 				{
 					Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
 					Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/NPCProj/HauntObjectThrow.cs
+++ b/Content/Projectiles/NPCProj/HauntObjectThrow.cs
@@ -72,7 +72,7 @@ namespace AssortedAdditions.Content.Projectiles.NPCProj
 
 			// Redraw the projectile with the color not influenced by light
 			Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-			for (int k = 0; k < Projectile.oldPos.Length; k++)
+			for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
 			{
 				Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
 				Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/PetProj/IlluminatedCrystalPet.cs
+++ b/Content/Projectiles/PetProj/IlluminatedCrystalPet.cs
@@ -65,7 +65,7 @@ namespace AssortedAdditions.Content.Projectiles.PetProj
 
             // Redraw the projectile with the color not influenced by light
             Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-            for (int k = 0; k < Projectile.oldPos.Length; k++)
+            for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
             {
                 Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
                 Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/PetProj/PetHauntling.cs
+++ b/Content/Projectiles/PetProj/PetHauntling.cs
@@ -127,7 +127,7 @@ namespace AssortedAdditions.Content.Projectiles.PetProj
 
 				// Redraw the projectile with the color not influenced by light
 				Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-				for (int k = 0; k < Projectile.oldPos.Length; k++)
+				for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
 				{
 					Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
 					Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/RangedProj/FrostBowProj.cs
+++ b/Content/Projectiles/RangedProj/FrostBowProj.cs
@@ -13,7 +13,7 @@ namespace AssortedAdditions.Content.Projectiles.RangedProj
     {
         public override void SetStaticDefaults()
         {
-            ProjectileID.Sets.TrailCacheLength[Projectile.type] = 5; // The length of old position to be recorded
+            ProjectileID.Sets.TrailCacheLength[Projectile.type] = 10; // The length of old position to be recorded
             ProjectileID.Sets.TrailingMode[Projectile.type] = 3;
             // Actual trail is drawn in PreDraw()
         }
@@ -116,7 +116,7 @@ namespace AssortedAdditions.Content.Projectiles.RangedProj
 
 			// Redraw the projectile with the color not influenced by light
 			Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-            for (int k = 0; k < Projectile.oldPos.Length; k++)
+            for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
             {
                 Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
                 Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/RangedProj/GraniteChakramProj.cs
+++ b/Content/Projectiles/RangedProj/GraniteChakramProj.cs
@@ -56,7 +56,7 @@ namespace AssortedAdditions.Content.Projectiles.RangedProj
 
 			// Redraw the projectile with the color not influenced by light
 			Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-			for (int k = 0; k < Projectile.oldPos.Length; k++)
+			for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
 			{
 				Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
 				Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Projectiles/RangedProj/JungleChakramProj.cs
+++ b/Content/Projectiles/RangedProj/JungleChakramProj.cs
@@ -94,7 +94,7 @@ namespace AssortedAdditions.Content.Projectiles.RangedProj
 
             // Redraw the projectile with the color not influenced by light
             Vector2 drawOrigin = new Vector2(texture.Value.Width * 0.5f, Projectile.height * 0.5f);
-            for (int k = 0; k < Projectile.oldPos.Length; k++)
+            for (int k = Projectile.oldPos.Length - 1; k > 0; k--)
             {
                 Vector2 drawPos = Projectile.oldPos[k] - Main.screenPosition + drawOrigin + new Vector2(0f, Projectile.gfxOffY);
                 Color color = Projectile.GetAlpha(lightColor) * ((Projectile.oldPos.Length - k) / (float)Projectile.oldPos.Length);

--- a/Content/Tiles/Banners/MonsterBanners.cs
+++ b/Content/Tiles/Banners/MonsterBanners.cs
@@ -6,6 +6,8 @@ using Terraria.ModLoader;
 using Terraria.ObjectData;
 using Terraria.Enums;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using Terraria.GameContent.Drawing;
 
 namespace AssortedAdditions.Content.Tiles.Banners
 {
@@ -32,40 +34,59 @@ namespace AssortedAdditions.Content.Tiles.Banners
             Main.tileNoAttach[Type] = true;
             Main.tileLavaDeath[Type] = true;
             TileID.Sets.DisableSmartCursor[Type] = true;
+			TileID.Sets.MultiTileSway[Type] = true;
 
-            TileObjectData.newTile.CopyFrom(TileObjectData.Style1x2Top);
+			TileObjectData.newTile.CopyFrom(TileObjectData.Style1x2Top);
             TileObjectData.newTile.StyleHorizontal = true;
             TileObjectData.newTile.Height = 3;
             TileObjectData.newTile.CoordinateHeights = new int[] { 16, 16, 16 };
-            TileObjectData.newTile.AnchorTop = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide | AnchorType.SolidBottom | AnchorType.Platform, TileObjectData.newTile.Width, 0);
+            TileObjectData.newTile.AnchorTop = new AnchorData(AnchorType.SolidTile | AnchorType.SolidSide | AnchorType.SolidBottom | AnchorType.PlanterBox, TileObjectData.newTile.Width, 0);
             TileObjectData.newTile.StyleWrapLimit = 111;
-            TileObjectData.addTile(Type);
-            DustType = -1;
+			TileObjectData.newTile.DrawYOffset = -2;
+			
+            TileObjectData.newAlternate.CopyFrom(TileObjectData.newTile);
+            TileObjectData.newAlternate.AnchorTop = new AnchorData(AnchorType.Platform, TileObjectData.newTile.Width, 0);
+			TileObjectData.newAlternate.DrawYOffset = -10;
+            TileObjectData.addAlternate(0);
 
-            LocalizedText name = Language.GetText("Banner");
-            AddMapEntry(Color, name); // Name will be just Banner like the vanilla ones (set in localisation)
+			TileObjectData.addTile(Type);
+
+			DustType = -1;
+            AddMapEntry(Color, Language.GetText("MapObject.Banner"));
         }
 
         public override void NearbyEffects(int i, int j, bool closer)
         {
-            if (closer)
+            if (!closer)
             {
-                Main.SceneMetrics.hasBanner = true;
-                Main.SceneMetrics.NPCBannerBuff[BuffNPC] = true;
+                int tileStyle = TileObjectData.GetTileStyle(Main.tile[i, j]);
+                int itemType = TileLoader.GetItemDropFromTypeAndStyle(Type, tileStyle);
+
+                if (BuffNPC != 0)
+                {
+                    if (ItemID.Sets.BannerStrength.IndexInRange(itemType) && ItemID.Sets.BannerStrength[itemType].Enabled)
+                    {
+                        Main.SceneMetrics.NPCBannerBuff[BuffNPC] = true;
+                        Main.SceneMetrics.hasBanner = true;
+                    }
+                }
             }
         }
 
 		public override void SetDrawPositions(int i, int j, ref int width, ref int offsetY, ref int height, ref short tileFrameX, ref short tileFrameY)
 		{
-            // Offset for when the banner is placed off of platforms
-			Tile tile = Main.tile[i, j];
-			TileObjectData data = TileObjectData.GetTileData(tile);
-			int topLeftX = i - tile.TileFrameX / 18 % data.Width;
-			int topLeftY = j - tile.TileFrameY / 18 % data.Height;
-			if (WorldGen.IsBelowANonHammeredPlatform(topLeftX, topLeftY))
-			{
-				offsetY -= 8;
-			}
+			// Due to MultiTileVine rendering the tile 2 pixels higher than expected for modded tiles using TileObjectData.DrawYOffset, we need to add 2 to fix the math for correct drawing
+			offsetY += 2;
+        }
+
+		public override bool PreDraw(int i, int j, SpriteBatch spriteBatch)
+		{
+            Tile tile = Main.tile[i, j];
+            if (TileObjectData.IsTopLeft(tile))
+            {
+                Main.instance.TilesRenderer.AddSpecialPoint(i, j, TileDrawing.TileCounterType.MultiTileVine);
+            }
+			return false;
 		}
 	}
 }

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -1,5 +1,12 @@
 Mods: {
 	AssortedAdditions: {
+		ChatMessages.Permafrost: The ice caverns get colder...
+
+		PopupMessages: {
+			HardmodeOre: Repelled by a mechanical presence!
+			HardmodeOreAlt: Repelleted by two mechanical presences!
+		}
+
 		Buffs: {
 			DragonStaffBuff: {
 				DisplayName: It's a dragon!
@@ -1593,9 +1600,10 @@ Mods: {
 					Label: Use Modded Hardmode Ore Progression
 					Tooltip:
 						'''
+						Ores can be mined as follows:
 						Palladium/Cobalt: after Wall of Flesh
-						Mythril/Orichalcum: after The Destroyer
-						Adamantite/Titanium: after The Destroyer + Twins
+						Mythril/Orichalcum: after any Mech Boss or The Fire Dragon
+						Adamantite/Titanium: after any two Mech Bosses
 						'''
 				}
 

--- a/Localization/en-US.hjson
+++ b/Localization/en-US.hjson
@@ -1,10 +1,13 @@
 Mods: {
 	AssortedAdditions: {
-		ChatMessages.Permafrost: The ice caverns get colder...
+		ChatMessages: {
+			Permafrost: The ice caverns get coler...
+			HardmodeOres: "[Assorted Additions] Modded hardmode ore progression active! Check server config for details."
+		}
 
 		PopupMessages: {
-			HardmodeOre: Repelled by a mechanical presence!
-			HardmodeOreAlt: Repelleted by two mechanical presences!
+			HardmodeOre: Protected by a mechanical power!
+			HardmodeOreAlt: Protected by mechanical powers!
 		}
 
 		Buffs: {

--- a/build.txt
+++ b/build.txt
@@ -1,3 +1,3 @@
 displayName = Assorted Additions
 author = Jesse.
-version = 0.1.1.7
+version = 0.1.1.8

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 [B]v0.1.1.8[/B]
 
 [LIST]
-[*] Added popup text related to hardmode ore progression when mining ore
+[*] Added indicators for modded hardmode ore progression
 [*] Banners now sway in the wind + additional fixes to them
 [*] Minor adjustment of afterimage trail drawing
 [*] Fixed permafrost generating twice when killing twins

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,12 @@
 [B]v0.1.1.8[/B]
 
 [LIST]
+[*] Improved compatibility with Ultimate Skyblock mod
 [*] Added indicators for modded hardmode ore progression
-[*] Banners now sway in the wind + additional fixes to them
-[*] Minor adjustment of afterimage trail drawing
+[*] Added some chest loot to fishing crates. Also added Desert Mimic and Jungle Mimic loot to respective fishing crates.
+[*] Fixed banners: they now sway in the wind
 [*] Fixed permafrost generating twice when killing twins
+[*] Minor adjustment of afterimage trail drawing
 [*] Updated localization
 [/LIST]
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,10 @@
-[B]v0.1.1.7[/B]
+[B]v0.1.1.8[/B]
 
 [LIST]
-[*] Changes to hardmode ore progression: Mythril/Orichalcum can be mined after defeating Fire Dragon or any mech boss, Adamantite/Titanium can be mined after defeating at least two mech bosses. (Can still be toggled off)
-[*] Mech boss summoning items as well as a bunch of early hardmode items can now be crafted at regular anvils
-[*] Celestial Pillar enemies now drop fragments
-[*] Fire Dragon weapon drops can now also be crafted
-[*] Improved Dust Bringer Staff Projectile logic
+[*] Added popup text related to hardmode ore progression when mining ore
+[*] Banners now sway in the wind + additional fixes to them
+[*] Minor adjustment of afterimage trail drawing
+[*] Fixed permafrost generating twice when killing twins
+[*] Updated localization
 [/LIST]
 


### PR DESCRIPTION
- Improved compatibility with Ultimate Skyblock mod
- Added indicators for modded hardmode ore progression
- Added some chest loot to fishing crates. Also added Desert Mimic and Jungle Mimic loot to respective fishing crates.
- Fixed banners: they now sway in the wind
- Fixed permafrost generating twice when killing twins
- Minor adjustment of afterimage trail drawing
- Updated localization