### PR TITLE
fix rune of death not being immune to some traps

### DIFF
--- a/Common/GlobalNPCs/ModifiedLootDrops.cs
+++ b/Common/GlobalNPCs/ModifiedLootDrops.cs
@@ -187,7 +187,7 @@ namespace AssortedAdditions.Common.GlobalNPCs
 					break;
 
 				case NPCID.Dandelion:
-					npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<DandelionFlower>(), 3, 1, 1)); // 33% chance
+					npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<DandelionFlower>(), 6, 1, 1)); // 16% chance
 					break;
 
 				case NPCID.BigMimicCorruption:
@@ -197,7 +197,7 @@ namespace AssortedAdditions.Common.GlobalNPCs
 					break;
 
 				case NPCID.Ghost:
-					npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<GhostlyBlade>(), 12)); // 8% chance																		   
+					npcLoot.Add(ItemDropRule.Common(ModContent.ItemType<GhostlyBlade>(), 40)); // 2.5% chance																		   
 					npcLoot.Add(ItemDropRule.ByCondition(Condition.DownedMechBossAll.ToDropCondition(ShowItemDropInUI.Always), ModContent.ItemType<GraveFlowers>(), 20, 1)); // 5% chance to drop in hardmode
 					break;
 

--- a/Content/Items/Accessories/Runes/RuneOfDeath.cs
+++ b/Content/Items/Accessories/Runes/RuneOfDeath.cs
@@ -49,8 +49,8 @@ namespace AssortedAdditions.Content.Items.Accessories.Runes
 	{
 		public bool isWearingRuneOfDeath;
 
-		readonly HashSet<int> trapProjectiles = new HashSet<int>() 
-		{ 
+		readonly HashSet<int> trapProjectiles = new HashSet<int>()
+		{
 			ProjectileID.PoisonDart,
 			ProjectileID.GeyserTrap,
 			ProjectileID.PoisonDartTrap,
@@ -59,20 +59,35 @@ namespace AssortedAdditions.Content.Items.Accessories.Runes
 			ProjectileID.FlamethrowerTrap,
 			ProjectileID.FlamesTrap,
 			ProjectileID.Boulder,
-			ProjectileID.Explosives
+			ProjectileID.Explosives,
+			ProjectileID.BouncyBoulder,
+			ProjectileID.LifeCrystalBoulder,
+			ProjectileID.GasTrap,
+			ProjectileID.TNTBarrel,
+			ProjectileID.Landmine,
 		};
+
 
 		public override bool CanBeHitByProjectile(Projectile proj)
 		{
 			if (isWearingRuneOfDeath)
 			{
-				if(trapProjectiles.Contains(proj.type))
+				if (trapProjectiles.Contains(proj.type))
 				{
 					return false;
 				}
 			}
-
 			return true;
+		}
+
+		public override void ModifyHitByProjectile(Projectile proj, ref Player.HurtModifiers modifiers)
+		{
+			// Cancel explosive damage
+			// Probably very scuffed fix:
+			if(trapProjectiles.Contains(modifiers.DamageSource.SourceProjectileType) && isWearingRuneOfDeath)
+			{
+				modifiers.Cancel();
+			}
 		}
 
 		public override void ResetEffects()
@@ -95,13 +110,19 @@ namespace AssortedAdditions.Content.Items.Accessories.Runes
 			if (self.GetModPlayer<RuneOfDeathPlayer>().isWearingRuneOfDeath)
 			{
 				// And the tile is spikes
-				if(tileId == TileID.Spikes || tileId == TileID.WoodenSpikes)
+				if (TileID.Sets.TouchDamageImmediate[tileId] != 0)
 				{
 					return; // Dont call ApplyTouchDamage to skip taking damage
 				}
 			}
-			
+
 			orig(self, tileId, x, y); // otherwise call original method
 		}
+
+		//private static bool IsThorn(int tileId)
+		//{
+		//	;
+		//	return tileId == TileID.CorruptThorns || TileID.CrimsonThorns || TileID.JungleThorns || TileID.PlanteraThorns;
+		//}
 	}
 }

--- a/build.txt
+++ b/build.txt
@@ -1,3 +1,3 @@
 displayName = Assorted Additions
 author = Jesse.
-version = 0.1.1.8
+version = 0.1.1.9

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,7 @@
-[B]v0.1.1.8[/B]
+[B]v0.1.1.9[/B]
 
 [LIST]
-[*] Improved compatibility with Ultimate Skyblock mod
-[*] Added indicators for modded hardmode ore progression
-[*] Added some chest loot to fishing crates. Also added Desert Mimic and Jungle Mimic loot to respective fishing crates.
-[*] Fixed banners: they now sway in the wind
-[*] Fixed permafrost generating twice when killing twins
-[*] Minor adjustment of afterimage trail drawing
-[*] Updated localization
+[*] Fixed Rune of Death not giving immunity to: Bouncy boulder, Life Crystal Boulder, Poison gas trap and explosives, tnt barrels and landmines. Now also gives immunity against thorns.
+[*] Reduced drop rate of Ghostly Blade and Dandelion Flower.
 [/LIST]
 


### PR DESCRIPTION
[*] Fixed Rune of Death not giving immunity to: Bouncy boulder, Life Crystal Boulder, Poison gas trap and explosives, tnt barrels and landmines. Now also gives immunity against thorns.
[*] Reduced drop rate of Ghostly Blade and Dandelion Flower.